### PR TITLE
Add browser-based Python playground (Pyodide + CodeMirror)

### DIFF
--- a/pages/python/default.md
+++ b/pages/python/default.md
@@ -1,0 +1,36 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/theme/material-darker.min.css">
+<link rel="stylesheet" href="/python/python-playground.css">
+
+# Python Playground
+
+Write Python, run it entirely in your browser with Pyodide, and share it with a permalink.
+
+<div class="python-playground" id="python-playground">
+    <div class="python-playground__toolbar" role="toolbar" aria-label="Python playground controls">
+        <label for="python-version">Python version</label>
+        <select id="python-version" aria-describedby="runtime-status">
+            <option value="0.28.3" selected>Python 3.13 (Pyodide 0.28.3)</option>
+            <option value="0.27.7">Python 3.12 (Pyodide 0.27.7)</option>
+            <option value="0.26.4">Python 3.12 (Pyodide 0.26.4)</option>
+        </select>
+        <button type="button" id="run-python" class="btn btn-primary">Run code</button>
+        <button type="button" id="copy-permalink" class="btn">Copy permalink</button>
+        <span id="runtime-status" class="python-playground__status" role="status" aria-live="polite">Runtime not loaded</span>
+    </div>
+
+    <label class="python-playground__label" for="python-code">Python code</label>
+    <textarea id="python-code" name="python-code" spellcheck="false">print("Hello from Python!")</textarea>
+
+    <div class="python-playground__output-heading">
+        <strong>Output</strong>
+        <button type="button" id="clear-output" class="btn btn-sm">Clear</button>
+    </div>
+    <pre id="python-output" class="python-playground__output" aria-live="polite" aria-label="Python output"></pre>
+</div>
+
+<noscript>This playground needs JavaScript to load CodeMirror and run Python in your browser.</noscript>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/mode/python/python.min.js"></script>
+<script src="/python/python-playground.js"></script>

--- a/pages/python/frontmatter.yaml
+++ b/pages/python/frontmatter.yaml
@@ -1,0 +1,9 @@
+anchors:
+    active: false
+date: 13-08-2026
+mathjax: false
+menu: Python Playground
+metadata:
+    author: Rodrigo Girão Serrão
+    description: Write and run Python in your browser, then share the code with a permalink.
+title: Python Playground

--- a/pages/python/python-playground.css
+++ b/pages/python/python-playground.css
@@ -1,0 +1,73 @@
+.python-playground {
+    margin: 1.5rem 0;
+}
+
+.python-playground__toolbar,
+.python-playground__output-heading {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.python-playground__toolbar {
+    margin-bottom: 0.75rem;
+}
+
+.python-playground__toolbar select {
+    background: var(--body-background, #fff);
+    border: 1px solid #bcc3ce;
+    border-radius: 0.1rem;
+    color: inherit;
+    height: 1.8rem;
+    padding: 0 0.4rem;
+}
+
+.python-playground__status {
+    color: #66758c;
+    font-size: 0.85rem;
+}
+
+.python-playground__label {
+    display: block;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.python-playground .CodeMirror {
+    border: 1px solid #3b4351;
+    border-radius: 0.2rem;
+    font-family: "FiraCode Nerd Font Mono", monospace;
+    font-size: 0.9rem;
+    height: min(55vh, 32rem);
+    line-height: 1.5;
+}
+
+.python-playground__output-heading {
+    justify-content: space-between;
+    margin-top: 1rem;
+}
+
+.python-playground__output {
+    background: #191919;
+    border-radius: 0.2rem;
+    color: #e7e9ed;
+    min-height: 6rem;
+    overflow: auto;
+    padding: 0.8rem;
+    white-space: pre-wrap;
+}
+
+.python-playground__output.is-error {
+    color: #ffb3b3;
+}
+
+@media (max-width: 600px) {
+    .python-playground__toolbar > * {
+        flex: 1 1 auto;
+    }
+
+    .python-playground__status {
+        flex-basis: 100%;
+    }
+}

--- a/pages/python/python-playground.js
+++ b/pages/python/python-playground.js
@@ -1,0 +1,117 @@
+(function () {
+    "use strict";
+
+    const codeTextarea = document.getElementById("python-code");
+    if (!codeTextarea || typeof CodeMirror === "undefined") {
+        return;
+    }
+
+    const versionSelect = document.getElementById("python-version");
+    const runButton = document.getElementById("run-python");
+    const permalinkButton = document.getElementById("copy-permalink");
+    const clearButton = document.getElementById("clear-output");
+    const output = document.getElementById("python-output");
+    const status = document.getElementById("runtime-status");
+    const runtimes = new Map();
+
+    const editor = CodeMirror.fromTextArea(codeTextarea, {
+        indentUnit: 4,
+        lineNumbers: true,
+        mode: "python",
+        theme: "material-darker",
+        viewportMargin: Infinity,
+    });
+
+    function encodeCode(code) {
+        const bytes = new TextEncoder().encode(code);
+        let binary = "";
+        bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+        return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    }
+
+    function decodeCode(value) {
+        const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+        const binary = atob(padded);
+        return new TextDecoder().decode(Uint8Array.from(binary, (character) => character.charCodeAt(0)));
+    }
+
+    function loadScript(source) {
+        return new Promise((resolve, reject) => {
+            const script = document.createElement("script");
+            script.src = source;
+            script.onload = resolve;
+            script.onerror = () => reject(new Error("Could not download the selected Python runtime."));
+            document.head.appendChild(script);
+        });
+    }
+
+    async function getRuntime(version) {
+        if (!runtimes.has(version)) {
+            const runtimePromise = (async () => {
+                const indexURL = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
+                status.textContent = `Loading Pyodide ${version}…`;
+                await loadScript(`${indexURL}pyodide.js`);
+                return window.loadPyodide({ indexURL });
+            })();
+            runtimes.set(version, runtimePromise);
+        }
+        return runtimes.get(version);
+    }
+
+    async function runCode() {
+        runButton.disabled = true;
+        output.classList.remove("is-error");
+        output.textContent = "";
+
+        try {
+            const version = versionSelect.value;
+            const pyodide = await getRuntime(version);
+            pyodide.setStdout({ batched: (text) => { output.textContent += `${text}\n`; } });
+            pyodide.setStderr({ batched: (text) => { output.textContent += `${text}\n`; } });
+            status.textContent = `Running Python with Pyodide ${version}…`;
+            const result = await pyodide.runPythonAsync(editor.getValue());
+            if (result !== undefined) {
+                output.textContent += `${result.toString()}\n`;
+                if (result.destroy) result.destroy();
+            }
+            status.textContent = `Ready — Pyodide ${version}`;
+        } catch (error) {
+            output.classList.add("is-error");
+            output.textContent += `${error.message || error}\n`;
+            status.textContent = "Run failed";
+        } finally {
+            runButton.disabled = false;
+        }
+    }
+
+    async function copyPermalink() {
+        const url = new URL(window.location.href);
+        url.searchParams.set("code", encodeCode(editor.getValue()));
+        window.history.replaceState({}, "", url);
+        try {
+            await navigator.clipboard.writeText(url.toString());
+            permalinkButton.textContent = "Copied!";
+        } catch (_) {
+            window.prompt("Copy this permalink:", url.toString());
+        }
+        window.setTimeout(() => { permalinkButton.textContent = "Copy permalink"; }, 2000);
+    }
+
+    const sharedCode = new URLSearchParams(window.location.search).get("code");
+    if (sharedCode !== null) {
+        try {
+            editor.setValue(decodeCode(sharedCode));
+        } catch (_) {
+            status.textContent = "The permalink contains invalid code.";
+        }
+    }
+
+    runButton.addEventListener("click", runCode);
+    permalinkButton.addEventListener("click", copyPermalink);
+    clearButton.addEventListener("click", () => {
+        output.textContent = "";
+        output.classList.remove("is-error");
+    });
+    editor.setOption("extraKeys", { "Ctrl-Enter": runCode, "Cmd-Enter": runCode });
+}());


### PR DESCRIPTION
### Motivation
- Provide an in-browser Python editor and runner so users can write and execute Python without a server-side runtime.
- Allow selecting different Pyodide releases while defaulting to the newest stable runtime and load the runtime lazily to save bandwidth.
- Enable easy sharing via permalinks by encoding the editor contents into the page URL and restoring them on load.

### Description
- Added a new page at `/python` with its frontmatter (`pages/python/frontmatter.yaml`) and markup (`pages/python/default.md`) embedding a CodeMirror editor, run/clear controls, a runtime version dropdown, a runtime status element, and an output console.
- Added `pages/python/python-playground.js` which wires CodeMirror, lazily loads Pyodide from a CDN (jsDelivr) per selected version, captures stdout/stderr, runs `pyodide.runPythonAsync`, and exposes keyboard shortcuts (`Ctrl-Enter` / `Cmd-Enter`).
- Implemented URL-safe base64 `code` query parameter encode/decode functions to create and restore permalinks and a `Copy permalink` button that writes the permalink to the clipboard with a manual-fallback prompt.
- Added responsive, accessible styling and layout in `pages/python/python-playground.css`, and included ARIA attributes and status messaging for runtime and error states.

### Testing
- Ran `node --check pages/python/python-playground.js` to validate the new JavaScript and it passed.
- Executed a smoke check that verifies the new frontmatter and page markup are present and correct, which passed.
- Repository preflight/diff checks were run (pre-commit/diff-style validation) and reported no blocking issues for the new files.
- Note: live Pyodide runtime execution and headless browser screenshots were not run because outbound CDN access and a Chromium browser were unavailable in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df5d7938483259d72573cdc83698a)